### PR TITLE
Add air live reload

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -14,7 +14,7 @@ tmp_dir = "tmp"
   follow_symlink = false
   full_bin = "RULESET=./ruleset.yaml ./tmp/main"
   include_dir = []
-  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_ext = ["go", "tpl", "tmpl", "yaml", "html"]
   include_file = []
   kill_delay = "0s"
   log = "build-errors.log"

--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+root = "./"
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ./cmd"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = "RULESET=./ruleset.yaml ./tmp/main"
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = ["echo 'dev' > handlers/VERSION"]
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = true
+
+[screen]
+  clear_on_rebuild = true
+  keep_scroll = true

--- a/README.md
+++ b/README.md
@@ -193,4 +193,14 @@ echo "dev" > handlers/VERSION
 RULESET="./ruleset.yaml" go run cmd/main.go
 ```
 
+### Optional: Live reloading development server with [cosmtrek/air](https://github.com/cosmtrek/air)
+
+Install air according to the [installation instructions](https://github.com/cosmtrek/air#installation). 
+
+Run a development server at http://localhost:8080:
+
+```bash
+air # or the path to air if you haven't added a path alias to your .bashrc or .zshrc
+```
+
 This project uses [pnpm](https://pnpm.io/) to build a stylesheet with the [Tailwind CSS](https://tailwindcss.com/) classes. For local development, if you modify styles in `form.html`, run `pnpm build` to generate a new stylesheet.


### PR DESCRIPTION
This is a very small PR to add a [cosmtrek/air](https://github.com/cosmtrek/air) configuration file to the project. It's pretty much the default air configuration with a couple minor tweaks.

Air is a pretty great CLI that provides live reload functionality for dev purposes. It's optional to use air for dev, but it certainly makes things more convenient not needing to stop and restart the server when working on code changes.

If you have Air installed, you can simply run `air` from the project root dir (or the path alias to air if you haven't added it to your `.bashrc` or `.zshrc`) and it will build the project to the `tmp` dir and watch for saved changes that would cause a live reload. It cleans up the `tmp` folder automatically when you stop the dev server.