### PR TITLE
Add random IP generation for bots

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,7 +101,7 @@ func main() {
 	}
 
 	if *randomBingBot {
-		err := bot.GoogleBot.UpdatePool("https://www.bing.com/toolbox/bingbot.json")
+		err := bot.BingBot.UpdatePool("https://www.bing.com/toolbox/bingbot.json")
 		if err != nil {
 			fmt.Println("error while retrieving list of Bingbot IPs: " + err.Error())
 			fmt.Println("defaulting to known trusted Bingbot identity")

--- a/proxychain/requestmodifers/bot/bot_test.go
+++ b/proxychain/requestmodifers/bot/bot_test.go
@@ -1,0 +1,28 @@
+package bot
+
+import (
+	"net"
+	"testing"
+)
+
+func TestRandomIPFromSubnet(t *testing.T) {
+	subnets := []string{"34.100.182.96/28", "207.46.13.0/24", "2001:4860:4801:10::/64", "2001:4860:4801:c::/64"}
+
+	for _, subnet := range subnets {
+		t.Run(subnet, func(t *testing.T) {
+			_, ipnet, err := net.ParseCIDR(subnet)
+			if err != nil {
+				t.Error(err)
+			}
+
+			ip, err := randomIPFromSubnet(subnet)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if !ipnet.Contains(ip) {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/proxychain/requestmodifers/bot/bot_test.go
+++ b/proxychain/requestmodifers/bot/bot_test.go
@@ -6,9 +6,17 @@ import (
 )
 
 func TestRandomIPFromSubnet(t *testing.T) {
-	subnets := []string{"34.100.182.96/28", "207.46.13.0/24", "2001:4860:4801:10::/64", "2001:4860:4801:c::/64"}
+	err := GoogleBot.UpdatePool("https://developers.google.com/static/search/apis/ipranges/googlebot.json")
+	if err != nil {
+		t.Error(err)
+	}
 
-	for _, subnet := range subnets {
+	for _, prefix := range GoogleBot.IPPool.Prefixes {
+		subnet := prefix.IPv4
+		if prefix.IPv6 != "" {
+			subnet = prefix.IPv6
+		}
+
 		t.Run(subnet, func(t *testing.T) {
 			_, ipnet, err := net.ParseCIDR(subnet)
 			if err != nil {


### PR DESCRIPTION
Also fixed a typo in `main.go`.
Works with every IP (whether v4 or v6) in the [Googlebot pool](https://developers.google.com/static/search/apis/ipranges/googlebot.json)

To elaborate on the comments I included if anyone in the future sees this (and so I understand it better):
`11111111 11111111 11111111 11110000` is the mask of a IPv4 CIDR block of /28, meaning it is in total 32 bits long and has 4 empty bits.
`emptyBits ** 2` is the amount of IPs in that block.
So if we had `34.100.182.96/28`, our range is `34.100.182.[96-111]`.
The same premise works for IPv6 addresses, the mask just increases to a size of 64 bits.