### PR TITLE
HTTP Timeout

### DIFF
--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,12 +23,16 @@ var (
 	ForwardedFor   = getenv("X_FORWARDED_FOR", "66.249.66.1")
 	rulesSet       = ruleset.NewRulesetFromEnv()
 	allowedDomains = []string{}
+	defaultTimeout = 15 // in seconds
 )
 
 func init() {
 	allowedDomains = strings.Split(os.Getenv("ALLOWED_DOMAINS"), ",")
 	if os.Getenv("ALLOWED_DOMAINS_RULESET") == "true" {
 		allowedDomains = append(allowedDomains, rulesSet.Domains()...)
+	}
+	if timeoutStr := os.Getenv("HTTP_TIMEOUT"); timeoutStr != "" {
+		defaultTimeout, _ = strconv.Atoi(timeoutStr)
 	}
 }
 
@@ -183,7 +188,7 @@ func fetchSite(urlpath string, queries map[string]string) (string, *http.Request
 
 	// Fetch the site
 	client := &http.Client{
-		Timeout: time.Second * 15,
+		Timeout: time.Second * time.Duration(defaultTimeout),
 	}
 	req, _ := http.NewRequest("GET", url, nil)
 

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"ladder/pkg/ruleset"
 
@@ -181,7 +182,9 @@ func fetchSite(urlpath string, queries map[string]string) (string, *http.Request
 	}
 
 	// Fetch the site
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: time.Second * 15,
+	}
 	req, _ := http.NewRequest("GET", url, nil)
 
 	if rule.Headers.UserAgent != "" {


### PR DESCRIPTION
This pull request introduces a configurable timeout feature for http client. The default timeout is set to 15 seconds, but users can now modify it by utilizing the HTTP_TIMEOUT environment variable.